### PR TITLE
Add repository priority attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Key                             | Type   | Description         | Default
 - **uri** - uri of the repo
 - **autorefresh** - enable autorefresh
 - **key** - location of repo key to import
+- **priority** - priority of the repo
 
 ## Example Usage
 

--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -16,6 +16,7 @@ action :add do
     shellout = Mixlib::ShellOut.new(command, user: 'root').run_command
     if shellout.stderr.empty?
       new_resource.updated_by_last_action true
+      set_priority
     else
       Chef::Log.error("Error adding repo: #{shellout.stderr}")
     end
@@ -57,4 +58,15 @@ def import_key
                                 run_context)
   cmd.command "rpm --import #{new_resource.key}"
   cmd.run_action :run
+end
+
+def set_priority
+  unless new_resource.priority.nil? or new_resource.priority <= 0
+    command = 'zypper mr'
+    command << " -p #{new_resource.priority} \"#{new_resource.repo_name}\""
+    shellout = Mixlib::ShellOut.new(command, user: 'root').run_command
+    if not shellout.stderr.empty?
+      Chef::Log.error("Error setting repo priority: #{shellout.stderr}")
+    end
+  end
 end

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -5,3 +5,4 @@ attribute :repo_name, kind_of: String, name_attribute: true
 attribute :autorefresh, kind_of: [TrueClass, FalseClass]
 attribute :uri, kind_of: String
 attribute :key, kind_of: String, default: nil
+attribute :priority, kind_of: Integer, default: nil

--- a/test/cookbooks/zypper-test/recipes/default.rb
+++ b/test/cookbooks/zypper-test/recipes/default.rb
@@ -14,3 +14,9 @@ zypper_repo 'jenkins' do
   key 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key'
   uri 'http://pkg.jenkins-ci.org/opensuse/'
 end
+
+zypper_repo 'add_dvd_repo_high_priority' do
+  repo_name 'SLES11SP3-x64 DVD2 Online'
+  uri 'http://demeter.uni-regensburg.de/SLES11SP3-x64/DVD2/'
+  priority 10
+end


### PR DESCRIPTION
A "priority" integer attribute is added for the "add" action.
If the add is successful, it will run:
  zypper mr -p <priority> <repo_name>
