### PR TITLE
add chef_version_for_provides

### DIFF
--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -1,3 +1,7 @@
+
+chef_version_for_provides "< 14.0" if defined?(:chef_version_for_provides)
+resource_name :zypper_repo
+
 actions :add, :remove
 default_action :add
 


### PR DESCRIPTION
this disables the cookbook resource on chef > 14.4 and removes the
deprecated feature logspam.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>